### PR TITLE
Restore/Logips bug

### DIFF
--- a/ipset-country
+++ b/ipset-country
@@ -20,7 +20,7 @@
 # CONFIGURATION:
 # --------------
 
-# OS: "auto", "manual", "debian", "sles" or "redhat" (default is auto)
+# OS: "auto", "manual", "debian" or "redhat" (default is auto)
 # Manual example: confdir="/etc/iptables", rulesfile="${confdir}/myrules"
 
 DISTRO="auto"
@@ -30,7 +30,6 @@ DISTRO="auto"
 # Example: "CN,China; US,United States; RU,Russia"
 
 COUNTRY="CN,China; RU,Russia"
-# TO BE ADDED: ;KP,Korea; RU,Russia"
 
 # ---[ FIREWALLS AND OPTIONS  ]-------------------------------------------------
 # Iptables and ipset are used by default to create the chains, rules and ipsets
@@ -145,10 +144,6 @@ func_vars() {
         confdir="/etc/sysconfig"
         rulesfile="${confdir}/ip6tables"
         ;;
-      sles)
-          confdir="/etc/ipset-country"
-          rulesfile="${confdir}/rules"
-        ;;
     esac
   else
     ipt="ip"
@@ -164,10 +159,6 @@ func_vars() {
           confdir="/etc/sysconfig"
           rulesfile="${confdir}/iptables"
         ;;
-      sles)
-          confdir="/etc/ipset-country"
-          rulesfile="${confdir}/rules"
-        ;;
     esac
   fi
   if [ -x "/usr/sbin/${ipt}tables-legacy" ]; then
@@ -175,9 +166,9 @@ func_vars() {
     iptrestore="/usr/sbin/${ipt}tables-legacy-restore"
     iptsave="/usr/sbin/${ipt}tables-legacy-save"
   else
-    iptables="/usr/sbin/${ipt}tables"
-    iptrestore="/usr/sbin/${ipt}tables-restore"
-    iptsave="/usr/sbin/${ipt}tables-save"
+    iptables="/sbin/${ipt}tables"
+    iptrestore="/sbin/${ipt}tables-restore"
+    iptsave="/sbin/${ipt}tables-save"
   fi
   if [ "$FIREWALLD" -eq 1 ]; then
     frontend="firewalld"
@@ -250,10 +241,12 @@ func_ipt_res() {
   if { [ "$proto" = "ipv4" ] && [ "$iptr_run" -ne 1 ]; } ||
      { [ "$proto" = "ipv6" ] && [ "$ip6r_run" -ne 1 ]; }
   then
-    $iptrestore < "$rulesfile" && ipt_r="OK" || ipt_r="NOK"
-    func_msg "$frontend: restore - $ipt_r"
-    [ "$proto" = "ipv4" ] && iptr_run=1
-    [ "$proto" = "ipv6" ] && ip6r_run=1
+    if [ "$ipt_r" == "OK" ] ; then
+      $iptrestore < "$rulesfile" && ipt_r="OK" || ipt_r="NOK"
+      func_msg "$frontend: restore - $ipt_r"
+      [ "$proto" = "ipv4" ] && iptr_run=1
+      [ "$proto" = "ipv6" ] && ip6r_run=1
+    fi
   fi
 }
 
@@ -501,6 +494,7 @@ func_block_ip() {
               fi
             else
               func_ips_create
+              [ "$RESTORE" -eq 1 ] && func_ipt_res
               func_ips_add
               if [ "$MODE" = "accept" ]; then
                 # whitelist
@@ -526,7 +520,6 @@ if [ "$IPV4" -eq 1 ]; then
   proto="ipv4"
   if [ "$LOGIPS" -eq 1 ] && [ "$FIREWALLD" -ne 1 ]; then
     func_vars
-    [ "$RESTORE" -eq 1 ] && func_ipt_res
     func_ipt_log
   fi
   if [ -z "$IPBLOCK_URL_V4" ]; then
@@ -540,7 +533,6 @@ if [ "$IPV6" -eq 1 ]; then
   proto="ipv6"
   if [ "$LOGIPS" -eq 1 ] && [ "$FIREWALLD" -ne 1 ]; then
     func_vars
-    [ "$RESTORE" -eq 1 ] && func_ipt_res
     func_ipt_log
   fi
   if [ -z "$IPBLOCK_URL_V6" ]; then

--- a/ipset-country
+++ b/ipset-country
@@ -30,6 +30,7 @@ DISTRO="auto"
 # Example: "CN,China; US,United States; RU,Russia"
 
 COUNTRY="CN,China; RU,Russia"
+# TO BE ADDED: ;KP,Korea; RU,Russia"
 
 # ---[ FIREWALLS AND OPTIONS  ]-------------------------------------------------
 # Iptables and ipset are used by default to create the chains, rules and ipsets
@@ -145,8 +146,8 @@ func_vars() {
         rulesfile="${confdir}/ip6tables"
         ;;
       sles)
-          confdir="/etc/sysconfig"
-          rulesfile="${confdir}/iptables"
+          confdir="/etc/ipset-country"
+          rulesfile="${confdir}/rules"
         ;;
     esac
   else
@@ -164,31 +165,19 @@ func_vars() {
           rulesfile="${confdir}/iptables"
         ;;
       sles)
-          confdir="/etc/sysconfig"
-          rulesfile="${confdir}/iptables"
+          confdir="/etc/ipset-country"
+          rulesfile="${confdir}/rules"
         ;;
     esac
   fi
   if [ -x "/usr/sbin/${ipt}tables-legacy" ]; then
-    if [ "${DISTRO}" == "sles" ] ; then
-      iptables="/usr/sbin/${ipt}tables-legacy"
-      iptrestore="/usr/sbin/${ipt}tables-legacy-restore"
-      iptsave="/usr/sbin/${ipt}tables-legacy-save"
-    else
-      iptables="/sbin/${ipt}tables-legacy"
-      iptrestore="/sbin/${ipt}tables-legacy-restore"
-      iptsave="/sbin/${ipt}tables-legacy-save"
-    fi
+    iptables="/usr/sbin/${ipt}tables-legacy"
+    iptrestore="/usr/sbin/${ipt}tables-legacy-restore"
+    iptsave="/usr/sbin/${ipt}tables-legacy-save"
   else
-    if [ "${DISTRO}" == "sles" ] ; then
-      iptables="/usr/sbin/${ipt}tables"
-      iptrestore="/usr/sbin/${ipt}tables-restore"
-      iptsave="/usr/sbin/${ipt}tables-save"
-    else
-      iptables="/sbin/${ipt}tables"
-      iptrestore="/sbin/${ipt}tables-restore"
-      iptsave="/sbin/${ipt}tables-save"
-    fi
+    iptables="/usr/sbin/${ipt}tables"
+    iptrestore="/usr/sbin/${ipt}tables-restore"
+    iptsave="/usr/sbin/${ipt}tables-save"
   fi
   if [ "$FIREWALLD" -eq 1 ]; then
     frontend="firewalld"
@@ -512,7 +501,6 @@ func_block_ip() {
               fi
             else
               func_ips_create
-              [ "$RESTORE" -eq 1 ] && func_ipt_res
               func_ips_add
               if [ "$MODE" = "accept" ]; then
                 # whitelist
@@ -538,6 +526,7 @@ if [ "$IPV4" -eq 1 ]; then
   proto="ipv4"
   if [ "$LOGIPS" -eq 1 ] && [ "$FIREWALLD" -ne 1 ]; then
     func_vars
+    [ "$RESTORE" -eq 1 ] && func_ipt_res
     func_ipt_log
   fi
   if [ -z "$IPBLOCK_URL_V4" ]; then
@@ -551,6 +540,7 @@ if [ "$IPV6" -eq 1 ]; then
   proto="ipv6"
   if [ "$LOGIPS" -eq 1 ] && [ "$FIREWALLD" -ne 1 ]; then
     func_vars
+    [ "$RESTORE" -eq 1 ] && func_ipt_res
     func_ipt_log
   fi
   if [ -z "$IPBLOCK_URL_V6" ]; then

--- a/ipset-country
+++ b/ipset-country
@@ -20,7 +20,7 @@
 # CONFIGURATION:
 # --------------
 
-# OS: "auto", "manual", "debian" or "redhat" (default is auto)
+# OS: "auto", "manual", "debian", "sles" or "redhat" (default is auto)
 # Manual example: confdir="/etc/iptables", rulesfile="${confdir}/myrules"
 
 DISTRO="auto"
@@ -144,6 +144,10 @@ func_vars() {
         confdir="/etc/sysconfig"
         rulesfile="${confdir}/ip6tables"
         ;;
+      sles)
+          confdir="/etc/sysconfig"
+          rulesfile="${confdir}/iptables"
+        ;;
     esac
   else
     ipt="ip"
@@ -159,16 +163,32 @@ func_vars() {
           confdir="/etc/sysconfig"
           rulesfile="${confdir}/iptables"
         ;;
+      sles)
+          confdir="/etc/sysconfig"
+          rulesfile="${confdir}/iptables"
+        ;;
     esac
   fi
   if [ -x "/usr/sbin/${ipt}tables-legacy" ]; then
-    iptables="/usr/sbin/${ipt}tables-legacy"
-    iptrestore="/usr/sbin/${ipt}tables-legacy-restore"
-    iptsave="/usr/sbin/${ipt}tables-legacy-save"
+    if [ "${DISTRO}" = "sles" ] ; then
+      iptables="/usr/sbin/${ipt}tables-legacy"
+      iptrestore="/usr/sbin/${ipt}tables-legacy-restore"
+      iptsave="/usr/sbin/${ipt}tables-legacy-save"
+    else
+      iptables="/sbin/${ipt}tables-legacy"
+      iptrestore="/sbin/${ipt}tables-legacy-restore"
+      iptsave="/sbin/${ipt}tables-legacy-save"
+    fi
   else
-    iptables="/sbin/${ipt}tables"
-    iptrestore="/sbin/${ipt}tables-restore"
-    iptsave="/sbin/${ipt}tables-save"
+    if [ "${DISTRO}" = "sles" ] ; then
+      iptables="/usr/sbin/${ipt}tables"
+      iptrestore="/usr/sbin/${ipt}tables-restore"
+      iptsave="/usr/sbin/${ipt}tables-save"
+    else
+      iptables="/sbin/${ipt}tables"
+      iptrestore="/sbin/${ipt}tables-restore"
+      iptsave="/sbin/${ipt}tables-save"
+    fi
   fi
   if [ "$FIREWALLD" -eq 1 ]; then
     frontend="firewalld"
@@ -241,12 +261,10 @@ func_ipt_res() {
   if { [ "$proto" = "ipv4" ] && [ "$iptr_run" -ne 1 ]; } ||
      { [ "$proto" = "ipv6" ] && [ "$ip6r_run" -ne 1 ]; }
   then
-    if [ "$ipt_r" == "OK" ] ; then
-      $iptrestore < "$rulesfile" && ipt_r="OK" || ipt_r="NOK"
-      func_msg "$frontend: restore - $ipt_r"
-      [ "$proto" = "ipv4" ] && iptr_run=1
-      [ "$proto" = "ipv6" ] && ip6r_run=1
-    fi
+    $iptrestore < "$rulesfile" && ipt_r="OK" || ipt_r="NOK"
+    func_msg "$frontend: restore - $ipt_r"
+    [ "$proto" = "ipv4" ] && iptr_run=1
+    [ "$proto" = "ipv6" ] && ip6r_run=1
   fi
 }
 
@@ -495,6 +513,7 @@ func_block_ip() {
             else
               func_ips_create
               [ "$RESTORE" -eq 1 ] && func_ipt_res
+              [ "$LOGIPS" -eq 1 ] && func_ipt_log
               func_ips_add
               if [ "$MODE" = "accept" ]; then
                 # whitelist


### PR DESCRIPTION
I encountered a bug if RESTORE=1 and LOGIPS=1.
Since func_ips_res is called after func_ips_log the restore overrides the logips chain.
I fixed this by calling the func_log_ips again, after the fuct_ipt_res. 