### PR TITLE
Moved config to seperate file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.*
+!.gitignore

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ In case of issues check the log file (/var/log/ipset-country.log)
 
 Configuration
 -------------
+***All options are set and explained in the conf file: [options.conf](options.conf)***  
+It is advisable to copy this options.conf to ".options.conf" before making any changes (to avoid custom config push to git).
 
-***All options are set and explained in the script itself: [ipset-country](ipset-country)***
 
 **Distro:**
 
@@ -52,7 +53,7 @@ Example:
 
 ---
 
-**Firewalls and options:** 
+**Firewalls and options:**
 
 Iptables and ipset are used by default to create the chains, rules and ipsets. If firewalld frontend is enabled it will be used instead.
 
@@ -99,7 +100,7 @@ Useful ipset commands:
 
 Changes
 -------
-
+- [20201202] moved the configuration to conf file (by srulikuk)
 - [20200927] fixed restore + logips bug (pr #10 by G4bbix)
 - [20200605] added Blacklist/Whitelist mode (#3)
 - [20200129] added option to DROP instead of REJECT (#1)
@@ -114,4 +115,3 @@ Other
 -----
 
 Also available: [github.com/tokiclover/dotfiles/blob/master/bin/ips.bash](https://github.com/tokiclover/dotfiles/blob/master/bin/ips.bash)
-

--- a/ipset-country
+++ b/ipset-country
@@ -9,6 +9,9 @@
 # INSTALLATION:
 # -------------
 
+# Configuration file is options.conf
+# It is advisable to copy options.conf to ".options.conf"
+
 # - Setup firewall if you have not done so yet, at least INPUT chain is needed
 # - Run this script from cron, e.g. /etc/cron.daily
 # - To run on boot you can also add it to e.g. /etc/rc.local or systemd
@@ -17,71 +20,7 @@
 # NOTE: This script will insert an iptables REJECT or DROP rule for ipset,
 # make sure you do not lock yourself out in case of issues on a remote system
 
-# CONFIGURATION:
-# --------------
 
-# OS: "auto", "manual", "debian", "suse" or "redhat" (default is auto)
-# Manual example: confdir="/etc/iptables", rulesfile="${confdir}/myrules"
-
-DISTRO="auto"
-
-# Specify countries to block as 'ISOCODE,Name' (same as ipdeny.com)
-# Multiple entries should be seperated by semicolon
-# Example: "CN,China; US,United States; RU,Russia"
-
-COUNTRY="CN,China; RU,Russia"
-
-# ---[ FIREWALLS AND OPTIONS  ]-------------------------------------------------
-# Iptables and ipset are used by default to create the chains, rules and ipsets
-# Firewalld can be enabled to use firewalld-cmd frontend
-# UFW is an unsupported and untested frontend, but might work
-# Nftables can be used with firewalld, default is to use iptables-legacy
-# Blacklist: block specified Countries, set MODE to "reject" or "drop"
-# Whitelist: allow specified Countries and block all others, set "accept"
-
-# Iptables
-MODE="reject" # Set target to use when ip matches country [accept|drop|reject]
-RESTORE=0     # Run iptables-restore first, before adding rules [0/1]
-LOGIPS=1      # Create logips chain to log matches [0/1]
-
-# FirewallD
-FIREWALLD=0       # Use firewalld instead [0/1]
-FIREWALLD_MODE=0  # Set 0 for default Blacklist (drop), or 1 to Whitelist [0/1]
-FIREWALLD_RH8=0   # Enable firewalld on CentOS/RHEL 8, at your own risk [0/1]
-
-# UFW
-UFW=0 # Set to 1 to use iptables besides ufw, at your own risk [0/1]
-
-# ---[ BLOCK LIST PROVIDERS ]---------------------------------------------------
-# IPdeny: "http://www.ipdeny.com/ipblocks/data/aggregated" (aggregated ipv4)
-#         "http://www.ipdeny.com/ipv6/ipaddresses/blocks" (ipv6)
-#         "http://www.ipdeny.com/ipblocks/data/countries" (full ipv4)
-# IPverse: "http://ipverse.net/ipblocks/data/countries"
-# Others: should work if they offer (iso) country zonefiles with CIDR's
-# Notes: - the "aggregated" zonefiles are smaller in size
-#        - ipdeny has no md5sums for aggregated ipv6 zonefiles
-#        - ipverse does not offer md5sums at all (this autosets MD5CHECK=0)
-# Switch: comment ipdeny lines and uncomment line below to use ipverse instead
-#         IPBLOCK_URL="http://ipverse.net/ipblocks/data/countries"
-
-IPBLOCK_URL_V4="http://www.ipdeny.com/ipblocks/data/aggregated"
-IPBLOCK_URL_V6="http://www.ipdeny.com/ipv6/ipaddresses/blocks"
-IPV4=1      # Use ipv4, ipv6 or both
-IPV6=0      # For ipv6 also set IPBLOCK_URL_V6 [0/1]
-MD5CHECK=1  # Check zonefile md5sums [0/1]
-FORCE=0     # Run even if zonefile is unchanged [0/1]
-            # same as running './ipset-country force'
-FLUSH=0     # Flush ipset before adding zonefile [0/1]
-            # this will take care of removed ranges
-
-# Log to file, or to disable logging use: "/dev/null 2>&1"
-LOG="/var/log/ipset-country.log"
-# Level, see below and man syslog [0-7]
-# ( 0=emerg 1=alert crit=2 3=err 4=warning 5=notice 6=info 7=debug )
-LOGLVL=6
-
-# END OF CONFIG
-# -------------
 
 # Commands and script variables
 # ipset cmds  : ipset list | test setname <ip> | flush | destroy
@@ -90,6 +29,21 @@ LOGLVL=6
 #               ipt_l = log rule, ipt_r = restore
 # executables : ipt = ipt{,6}tables, iptrestore = ip{,6}tables-restore
 #               iptsave = ip{,6}tables-save
+
+# Source the vars
+current_dir="$(dirname "$0")"
+if [ -e "${current_dir}/.options.conf" ] ; then
+	# shellcheck source=.options.conf
+	. "${current_dir}/.options.conf"
+else
+	if [ -e "${current_dir}/options.conf" ] ; then
+		# shellcheck source=options.conf
+		. "${current_dir}/options.conf"
+	else
+		printf '\n[ERROR:] Cannot find the options source file\nEXIT\n'
+		exit 0
+	fi
+fi
 
 iptr_run=0; ip6r_run=0; logips_run=0; logip6_run=0
 nl='

--- a/ipset-country.service
+++ b/ipset-country.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=ipset-country
+
+[Service]
+Type=oneshot
+ExecStart=/my_scripts/ipset-country/ipset-country
+StandardError=file:/var/log/ipset-country.err
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/options.conf
+++ b/options.conf
@@ -1,0 +1,68 @@
+# It is advisable to copy this options.conf to ".options.conf"
+# before making any changes (to avoid custom config push to git). 
+
+# CONFIGURATION:
+# --------------
+
+# OS: "auto", "manual", "debian", "suse" or "redhat" (default is auto)
+# Manual example: confdir="/etc/iptables", rulesfile="${confdir}/myrules"
+
+DISTRO="auto"
+
+# Specify countries to block as 'ISOCODE,Name' (same as ipdeny.com)
+# Multiple entries should be seperated by semicolon
+# Example: "CN,China; US,United States; RU,Russia"
+
+COUNTRY="CN,China; RU,Russia"
+
+# ---[ FIREWALLS AND OPTIONS  ]-------------------------------------------------
+# Iptables and ipset are used by default to create the chains, rules and ipsets
+# Firewalld can be enabled to use firewalld-cmd frontend
+# UFW is an unsupported and untested frontend, but might work
+# Nftables can be used with firewalld, default is to use iptables-legacy
+# Blacklist: block specified Countries, set MODE to "reject" or "drop"
+# Whitelist: allow specified Countries and block all others, set "accept"
+
+# Iptables
+MODE="reject" # Set target to use when ip matches country [accept|drop|reject]
+RESTORE=0     # Run iptables-restore first, before adding rules [0/1]
+LOGIPS=1      # Create logips chain to log matches [0/1]
+
+# FirewallD
+FIREWALLD=0       # Use firewalld instead [0/1]
+FIREWALLD_MODE=0  # Set 0 for default Blacklist (drop), or 1 to Whitelist [0/1]
+FIREWALLD_RH8=0   # Enable firewalld on CentOS/RHEL 8, at your own risk [0/1]
+
+# UFW
+UFW=0 # Set to 1 to use iptables besides ufw, at your own risk [0/1]
+
+# ---[ BLOCK LIST PROVIDERS ]---------------------------------------------------
+# IPdeny: "http://www.ipdeny.com/ipblocks/data/aggregated" (aggregated ipv4)
+#         "http://www.ipdeny.com/ipv6/ipaddresses/blocks" (ipv6)
+#         "http://www.ipdeny.com/ipblocks/data/countries" (full ipv4)
+# IPverse: "http://ipverse.net/ipblocks/data/countries"
+# Others: should work if they offer (iso) country zonefiles with CIDR's
+# Notes: - the "aggregated" zonefiles are smaller in size
+#        - ipdeny has no md5sums for aggregated ipv6 zonefiles
+#        - ipverse does not offer md5sums at all (this autosets MD5CHECK=0)
+# Switch: comment ipdeny lines and uncomment line below to use ipverse instead
+#         IPBLOCK_URL="http://ipverse.net/ipblocks/data/countries"
+
+IPBLOCK_URL_V4="http://www.ipdeny.com/ipblocks/data/aggregated"
+IPBLOCK_URL_V6="http://www.ipdeny.com/ipv6/ipaddresses/blocks"
+IPV4=1      # Use ipv4, ipv6 or both
+IPV6=0      # For ipv6 also set IPBLOCK_URL_V6 [0/1]
+MD5CHECK=1  # Check zonefile md5sums [0/1]
+FORCE=0     # Run even if zonefile is unchanged [0/1]
+            # same as running './ipset-country force'
+FLUSH=0     # Flush ipset before adding zonefile [0/1]
+            # this will take care of removed ranges
+
+# Log to file, or to disable logging use: "/dev/null 2>&1"
+LOG="/var/log/ipset-country.log"
+# Level, see below and man syslog [0-7]
+# ( 0=emerg 1=alert crit=2 3=err 4=warning 5=notice 6=info 7=debug )
+LOGLVL=6
+
+# END OF CONFIG
+# -------------


### PR DESCRIPTION
I moved all the configuration options to separate file and sourced it.
The idea is that one can have different config options on each server and by renaming the config file to start with '.' (dot) these configs are not pushed to git.

If you find these changes useful you are welcome to pull it, NOTE before pulling onto a production server move current config to .options.conf not to destroy your customised config.