### PR TITLE
Add a inject after/before setting

### DIFF
--- a/ipset-country
+++ b/ipset-country
@@ -42,7 +42,7 @@ COUNTRY="CN,China; RU,Russia"
 MODE="reject"       # Set target to use when ip matches country [accept|drop|reject]
 RESTORE=0           # Run iptables-restore first, before adding rules [0/1]
 LOGIPS=1            # Create logips chain to log matches [0/1]
-INJECT_RULE="after" # Only applied to iptables in reject/drop mode, injects the rule [after|before]
+DENY_POST_AT=0 # If zero, inject rule at the end by default. If higher than zero, inject at line
 
 # FirewallD
 FIREWALLD=0       # Use firewalld instead [0/1]
@@ -363,14 +363,13 @@ func_ipt_log() {
 
 # add ipset deny rule at last line in input chain or line number 1
 func_ipt_deny() {
-  if [ "$INJECT_RULE" = "after" ]; then
+  rulenum=$DENY_POST_AT
+  #Inject rule at the end if DENY_POST == 0
+  if [ $DENY_POST_AT -eq 0 ]; then
     rulenum=$(( $(${iptables} -S INPUT 2>/dev/null|wc -l) - 1 )) || rulenum=1
-  elif [ "$INJECT_RULE" = "before" ]; then
-    rulenum=1
-  else
-    echo "Error: invalid INJECT_RULE"  
-    exit 1
   fi
+  
+
   # alternative method, slower:
   # rulenum="$(( $(${iptables} -L INPUT --line-numbers | tail -1 | awk '{print $1}') - 1 ))"
   [ "$rulenum" -eq 0 ] && rulenum=1

--- a/ipset-country
+++ b/ipset-country
@@ -39,9 +39,10 @@ COUNTRY="CN,China; RU,Russia"
 # Whitelist: allow specified Countries and block all others, set "accept"
 
 # Iptables
-MODE="reject" # Set target to use when ip matches country [accept|drop|reject]
-RESTORE=0     # Run iptables-restore first, before adding rules [0/1]
-LOGIPS=1      # Create logips chain to log matches [0/1]
+MODE="reject"       # Set target to use when ip matches country [accept|drop|reject]
+RESTORE=0           # Run iptables-restore first, before adding rules [0/1]
+LOGIPS=1            # Create logips chain to log matches [0/1]
+INJECT_RULE="after" # Only applied to iptables in reject/drop mode, injects the rule [after|before]
 
 # FirewallD
 FIREWALLD=0       # Use firewalld instead [0/1]
@@ -362,7 +363,14 @@ func_ipt_log() {
 
 # add ipset deny rule at last line in input chain or line number 1
 func_ipt_deny() {
-  rulenum=$(( $(${iptables} -S INPUT 2>/dev/null|wc -l) - 1 )) || rulenum=1
+  if [ "$INJECT_RULE" = "after" ]; then
+    rulenum=$(( $(${iptables} -S INPUT 2>/dev/null|wc -l) - 1 )) || rulenum=1
+  elif [ "$INJECT_RULE" = "before" ]; then
+    rulenum=1
+  else
+    echo "Error: invalid INJECT_RULE"  
+    exit 1
+  fi
   # alternative method, slower:
   # rulenum="$(( $(${iptables} -L INPUT --line-numbers | tail -1 | awk '{print $1}') - 1 ))"
   [ "$rulenum" -eq 0 ] && rulenum=1


### PR DESCRIPTION
Just a simple addition, allowing to inject the rules before or after of the chain.
We had to inject the ipset bans before instead of the default setting (after).

With love
Mia